### PR TITLE
[메인페이지] open api 조회 로직 추가

### DIFF
--- a/common/src/main/java/com/pds/common/api/Fifa4PlayerApi.java
+++ b/common/src/main/java/com/pds/common/api/Fifa4PlayerApi.java
@@ -1,0 +1,61 @@
+package com.pds.common.api;
+
+
+import com.pds.common.dto.PlayerDto;
+import com.pds.common.dto.SeasonDto;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Component
+@RequiredArgsConstructor
+public class Fifa4PlayerApi {
+    private final RestTemplate restTemplate;
+    private final HttpEntity<String> requestEntity;
+
+    //No Test - 너무 오래걸림
+    public String getPlayerMetaData(){
+        ResponseEntity<String> responseEntity = restTemplate.exchange("https://static.api.nexon.co.kr/fifaonline4/latest/spid.json", HttpMethod.GET, requestEntity, String.class);
+        String response = responseEntity.getBody();
+        return "{data: " + response + "}";
+    }
+
+    public String getSeasonMetaData(){
+        ResponseEntity<String> responseEntity = restTemplate.exchange("https://static.api.nexon.co.kr/fifaonline4/latest/seasonid.json", HttpMethod.GET, requestEntity, String.class);
+        String response = responseEntity.getBody();
+        return "{data: " + response + "}";
+    }
+
+    public List<PlayerDto.PlayerApiResponse> fromJSONtoPlayer(String result) {
+        JSONObject jsonObject = new JSONObject(result);
+        JSONArray jsonArray = jsonObject.getJSONArray("data");
+        List<PlayerDto.PlayerApiResponse> player = new ArrayList<>();
+        for (int i = 0; i < jsonArray.length(); i++) {
+            JSONObject jsobj = (JSONObject) jsonArray.get(i);
+            PlayerDto.PlayerApiResponse pd = new PlayerDto.PlayerApiResponse(jsobj);
+            player.add(pd);
+        }
+        return player;
+    }
+
+    public List<SeasonDto> fromJSONtoSeason(String result){
+        List<SeasonDto> seasonDtoList = new ArrayList<>();
+        JSONObject jsonObject = new JSONObject(result);
+        JSONArray jsonArray = jsonObject.getJSONArray("data");
+        for(int i = 0; i < jsonArray.length(); i ++){
+            jsonObject = (JSONObject) jsonArray.get(i);
+            SeasonDto seasonDto = new SeasonDto(jsonObject);
+            seasonDtoList.add(seasonDto);
+        }
+        return seasonDtoList;
+    }
+}

--- a/common/src/main/java/com/pds/common/api/Fifa4PlayerImgApi.java
+++ b/common/src/main/java/com/pds/common/api/Fifa4PlayerImgApi.java
@@ -1,0 +1,47 @@
+package com.pds.common.api;
+
+
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+
+public final class Fifa4PlayerImgApi {
+
+    private Fifa4PlayerImgApi(){
+        //
+    }
+
+    public static final String DEFAULT_IMAGE = "https://ff4ggimages.s3.ap-northeast-2.amazonaws.com/unknown.png";
+
+    public static String findPlayerImgUrl(int playerId) {
+        try {
+            String url = "https://fo4.dn.nexoncdn.co.kr/live/externalAssets/common/playersAction/p" + playerId + ".png";
+            URL obj = new URL(url);
+            if(hasImage(obj)){
+                return url;
+            }
+            int code = playerId % (playerId / 1000000 * 10000);
+            String url2 = "https://fo4.dn.nexoncdn.co.kr/live/externalAssets/common/players/p" + code + ".png";
+            return (hasImage(new URL(url2))) ? url2 : DEFAULT_IMAGE;
+        } catch (MalformedURLException | ArithmeticException e ) {
+            e.printStackTrace();
+        }
+        return DEFAULT_IMAGE;
+
+    }
+    static boolean hasImage(URL obj){
+        try {
+            HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+            con.setRequestMethod("HEAD");
+            if (!con.getHeaderFields().get(null).get(0).contains("403")) {
+                return true;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/com/pds/common/api/Fifa4SearchUserApi.java
+++ b/common/src/main/java/com/pds/common/api/Fifa4SearchUserApi.java
@@ -1,0 +1,33 @@
+package com.pds.common.api;
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+@RequiredArgsConstructor
+public class Fifa4SearchUserApi {
+
+
+    private final RestTemplate restTemplate;
+    private final HttpEntity<String> requestEntity;
+
+    public String getUserInfo(String nickname) {
+        try{
+            ResponseEntity<String> responseEntity = restTemplate.exchange("https://api.nexon.co.kr/fifaonline4/v1.0/users?nickname=" + nickname, HttpMethod.GET, requestEntity, String.class);
+            return responseEntity.getBody();
+        }
+        catch(HttpClientErrorException e){
+            return null;
+        }
+    }
+    public String getUserAccessId(String reseponse){
+        return new JSONObject(reseponse).getString("accessId");
+    }
+}

--- a/common/src/main/java/com/pds/common/api/Fifa4SearchUserMatchApi.java
+++ b/common/src/main/java/com/pds/common/api/Fifa4SearchUserMatchApi.java
@@ -1,0 +1,56 @@
+package com.pds.common.api;
+
+
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+// 유저 아이디로 최근 개인순위경기 아이디를 얻습니다.
+@Component
+@RequiredArgsConstructor
+public class Fifa4SearchUserMatchApi {
+
+    private final RestTemplate restTemplate;
+    private final HttpEntity<String> requestEntity;
+
+    public String getUserMatch(String uId , int num) {
+        try {
+            ResponseEntity<String> responseEntity = restTemplate.exchange("https://api.nexon.co.kr/fifaonline4/v1.0/users/" + uId + "/matches?matchtype=50&offset=0&limit="+num, HttpMethod.GET, requestEntity, String.class);
+            String response = responseEntity.getBody();
+            return "{data: " + response + "}";
+
+        } catch (HttpClientErrorException e) {
+            return "{data: []}";
+        }
+    }
+    public String getUserMatchDetail(String match) {
+        try {
+            ResponseEntity<String> responseEntity = restTemplate.exchange("https://api.nexon.co.kr/fifaonline4/v1.0/matches/" + match, HttpMethod.GET, requestEntity, String.class);
+            String response = responseEntity.getBody();
+            return "{data: " + response + "}";
+        }
+        catch(HttpClientErrorException e){
+            return null;
+        }
+    }
+
+    public List<String> fromJSONtoMatchList(String result) {
+        List<String> list = new ArrayList<>();
+        JSONObject jsonObject = new JSONObject(result);
+        JSONArray ja = jsonObject.getJSONArray("data");
+        for (int i = 0; i < ja.length(); i++) {
+            list.add(ja.getString(i));
+        }
+        return list;
+    }
+}

--- a/common/src/test/java/com/pds/common/api/Fifa4PlayerApiTest.java
+++ b/common/src/test/java/com/pds/common/api/Fifa4PlayerApiTest.java
@@ -1,0 +1,41 @@
+package com.pds.common.api;
+
+
+import com.pds.common.config.Fifa4Api;
+import com.pds.common.dto.PlayerDto;
+import com.pds.common.dto.SeasonDto;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Fifa4Api.class , Fifa4PlayerApi.class})
+class Fifa4PlayerApiTest {
+
+    @Autowired
+    private Fifa4PlayerApi fifa4PlayerApi;
+
+    @Test
+    void getPlayerMetaDataTest(){
+        String res = "{data: [{\"id\": 507261070, \"name\": \"켄자바예프\" }]}";
+        JSONObject jsonObject = new JSONObject(res);
+        List<PlayerDto.PlayerApiResponse> playerApiResponseList =  fifa4PlayerApi.fromJSONtoPlayer(res);
+        assertEquals("켄자바예프",playerApiResponseList.get(0).getPlayerName());
+        assertEquals(507261070,playerApiResponseList.get(0).getPlayerId());
+    }
+
+    @Test
+    void getSeasonMetatDataTest(){
+        String res = fifa4PlayerApi.getSeasonMetaData();
+        assertNotNull(res);
+        List<SeasonDto> seasonDtoList = fifa4PlayerApi.fromJSONtoSeason(res);
+        assertNotEquals(0,seasonDtoList.size());
+    }
+
+}

--- a/common/src/test/java/com/pds/common/api/Fifa4PlayerImgApiTest.java
+++ b/common/src/test/java/com/pds/common/api/Fifa4PlayerImgApiTest.java
@@ -1,0 +1,24 @@
+package com.pds.common.api;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class Fifa4PlayerImgApiTest {
+
+    @Test
+    void test(){
+        assertEquals("https://fo4.dn.nexoncdn.co.kr/live/externalAssets/common/playersAction/p101000250.png", Fifa4PlayerImgApi.findPlayerImgUrl(101000250));
+    }
+    @Test
+    void noActionImgReturnTest(){
+        assertEquals("https://fo4.dn.nexoncdn.co.kr/live/externalAssets/common/players/p13743.png",Fifa4PlayerImgApi.findPlayerImgUrl(234013743));
+    }
+
+    @Test
+    void noImageReturnTest(){
+        assertEquals(Fifa4PlayerImgApi.DEFAULT_IMAGE,Fifa4PlayerImgApi.findPlayerImgUrl(111111111));
+    }
+}

--- a/common/src/test/java/com/pds/common/api/Fifa4UserApiTest.java
+++ b/common/src/test/java/com/pds/common/api/Fifa4UserApiTest.java
@@ -1,0 +1,72 @@
+package com.pds.common.api;
+
+
+import com.pds.common.config.Fifa4Api;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {Fifa4Api.class, Fifa4SearchUserApi.class,Fifa4SearchUserMatchApi.class})
+class Fifa4UserApiTest {
+
+
+    @Autowired
+    private Fifa4SearchUserApi userApi;
+
+    @Autowired
+    private Fifa4SearchUserMatchApi matchApi;
+
+    private final String userId = "5ff691ff0e8ce08e2874e0d3";
+
+    @Test
+    void getUserIdTest(){
+        String userName = "Youtube윤보미";
+        String res = userApi.getUserInfo(userName);
+        assertNotNull(res);
+        JSONObject jsonObject = new JSONObject(res);
+        assertEquals(userName,jsonObject.getString("nickname"));
+        assertEquals(userId,jsonObject.getString("accessId"));
+
+        assertEquals(userId,userApi.getUserAccessId(res));
+    }
+
+    @Test
+    void getUserNotExistTest(){
+        assertNull(userApi.getUserInfo("졵줴호ㅑ쥐왆뉸유젿윕ㄴ듀ㅣ다"));
+    }
+
+    @Test
+    void getUserMatchTest(){
+        // 내 친구가 너무 오래 게임을 안하면 실패할 수도 있다.
+        String res = matchApi.getUserMatch(userId,2);
+        assertNotNull(res);
+        assertNotEquals("{data: []}",res);
+
+        assertNotNull(matchApi.fromJSONtoMatchList(res));
+    }
+    @Test
+    void getUserMatchNotExistTest(){
+        String noMatchUserId = "fda01bf2f33bc25c1d5b6b12";
+        String res = matchApi.getUserMatch(noMatchUserId,1);
+        assertNotNull(res);
+        assertEquals("{data: []}",res);
+        //[]
+    }
+
+    @Test
+    void getUserMatchDetailTest(){
+        String matchId = "6139d4a6b4c3eaad958aee1e";
+        assertNotNull(matchApi.getUserMatchDetail(matchId));
+    }
+    @Test
+    void getInvalidMatchIdDetailTest(){
+        String matchId = "KKKKKKKK";
+        assertNull(matchApi.getUserMatchDetail(matchId));
+    }
+
+}


### PR DESCRIPTION
* 선수, 시즌 모든 메타데이터 수집
* 선수 이미지 조회
* 유저 닉네임으로 아이디 정보 수집
* 유저 아이디로 최근 순위경기 기록(코드) 수집
* 순위경기코드로 해당 경기 상세 정보 수집