### PR TITLE
[유저페이지] 비정상적인 메타데이터 전달 시 오류 해결

### DIFF
--- a/web/src/main/java/com/pds/web/controller/UserMatchController.java
+++ b/web/src/main/java/com/pds/web/controller/UserMatchController.java
@@ -2,6 +2,7 @@ package com.pds.web.controller;
 
 
 import com.pds.web.api.MatchDto;
+import com.pds.web.exception.ErrorInfo;
 import com.pds.web.service.UserMatchService;
 import com.pds.web.utils.ResponseHandler;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,12 @@ class UserMatchController {
 
     @GetMapping("/users/{id}/matches")
     public ResponseEntity<MatchDto.Info> getDetailFromMatchCode(@PathVariable String id , @RequestParam String mc){
-            return ResponseHandler.generateResponse("상세 순위경기 조회 OK", HttpStatus.OK,userMatchService.getDetailMatchList(mc,id));
+        MatchDto.Info result = userMatchService.getDetailMatchList(mc,id);
+        if(result!=null){
+            return ResponseHandler.generateResponse("상세 순위경기 조회 OK", HttpStatus.OK,result);
+        }
+        else{
+            return ResponseHandler.generateResponse(ErrorInfo.FF4_API_ERROR.getErrorMsg(),ErrorInfo.FF4_API_ERROR.getErrorCode(),HttpStatus.OK,result,"");
+        }
     }
 }

--- a/web/src/main/java/com/pds/web/service/UserMatchService.java
+++ b/web/src/main/java/com/pds/web/service/UserMatchService.java
@@ -29,7 +29,7 @@ public class UserMatchService {
                     MatchDeliver.playerInfo(objects),
                     MatchDeliver.shootInfo(objects));
         } catch (JSONException | NullPointerException e) {
-            throw new UserRequestException(ErrorInfo.FF4_API_ERROR);
+            return null;
         }
     }
 }

--- a/web/src/test/java/com/pds/web/controller/UserMatchControllerTest.java
+++ b/web/src/test/java/com/pds/web/controller/UserMatchControllerTest.java
@@ -60,14 +60,15 @@ class UserMatchControllerTest {
 
     }
     @Test
-    void getDetailFromMatchCodeExceptionTest() throws Exception{
+    void getDetailFromMatchCodeNullTest() throws Exception{
         given(matchService.getDetailMatchList("CODE","ID"))
                 //cover JSONException , NullPointerException
-                .willThrow(new UserRequestException(ErrorInfo.FF4_API_ERROR));
+                .willReturn(null);
         MvcResult result = mvc.perform(get("/users/{id}/matches","ID")
         .param("mc","CODE"))
-                .andExpect(status().isBadRequest()).andReturn();
-        assertEquals(ErrorInfo.FF4_API_ERROR.getErrorMsg(),result.getResolvedException().getMessage());
+                .andExpect(status().isOk()).andReturn();
+        JSONObject res = new JSONObject(result.getResponse().getContentAsString());
+        assertEquals(ErrorInfo.FF4_API_ERROR.getErrorCode(),res.getInt("code"));
     }
     @Test
     void getDetailFromMatchCodeMissingParamExceptionTest() throws Exception {

--- a/web/src/test/java/com/pds/web/service/UserMatchServiceTest.java
+++ b/web/src/test/java/com/pds/web/service/UserMatchServiceTest.java
@@ -6,6 +6,7 @@ import com.pds.web.api.MatchDto;
 import com.pds.web.api.MatchFinder;
 import com.pds.web.exception.ErrorInfo;
 import com.pds.web.exception.UserRequestException;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,17 +53,15 @@ class UserMatchServiceTest {
         objects.add(TestMatchDetail.matchList.get(1));
         given(matchFinder.getDetailMatchJsonListFromCodeList("CODE","ID"))
                 .willReturn(objects);
-        Exception e = assertThrows(UserRequestException.class ,
-                ()->matchService.getDetailMatchList("CODE","ID"));
-        assertEquals(ErrorInfo.FF4_API_ERROR.getErrorMsg() , e.getMessage());
-
+        assertNull(matchService.getDetailMatchList("CODE","ID"));
     }
     @Test
     void getDetailMatchNullTest(){
         given(matchFinder.getDetailMatchJsonListFromCodeList("CODE","ID"))
-                .willReturn(null);
-        Exception e = assertThrows(UserRequestException.class ,
-                ()->matchService.getDetailMatchList("CODE","ID"));
-        assertEquals(ErrorInfo.FF4_API_ERROR.getErrorMsg() , e.getMessage());
+                .willThrow(new JSONException(""));
+        assertNull(matchService.getDetailMatchList("CODE", "ID"));
+        given(matchFinder.getDetailMatchJsonListFromCodeList("CODE2","ID2"))
+                .willThrow(new NullPointerException());
+        assertNull(matchService.getDetailMatchList("CODE2", "ID2"));
     }
 }


### PR DESCRIPTION
* 잘못된 메타데이터가 없었으면 좋겠지만 있다.
* 이에 대해 예외처리를 해두고 예외를 리턴하게 했다.
* 유저 순위경기 정보 전달 시 비동기처리를 하게 되는데 하나라도 예외 또는 자바스크립트에서 reject면 모두 전달에 실패한다. 따라서 1개의 경기만 메타데이터가 잘못되어있으면 유저조회페이지에서 아무것도 나타나지 않게된다.
* 따라서 statuscode는 200으로 하되 잘못된 데이터가 있다는 것만 나타내줄 수 있도록 변경한다.