### PR TITLE
기대득점 응답 방식 변경

### DIFF
--- a/serverlessapi/src/main/java/com/pds/serverlessapi/api/XgApi.java
+++ b/serverlessapi/src/main/java/com/pds/serverlessapi/api/XgApi.java
@@ -8,13 +8,17 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class XgApi {
     private final RestTemplate restTemplate;
     private final HttpHeaders headers;
 
-    private final String errorLog = "Xg API";
+    private static final String ERROR_LOG = "Xg API";
 
     public XgDto getXgVal(String shootInfo){
         try{
@@ -23,9 +27,22 @@ public class XgApi {
         }
         catch(HttpClientErrorException | HttpServerErrorException e){
             if (e.getRawStatusCode() == 429 || e.getRawStatusCode() == 403) {
-                throw new HttpClientErrorException(HttpStatus.FORBIDDEN , errorLog);
+                throw new HttpClientErrorException(HttpStatus.FORBIDDEN , ERROR_LOG);
             }  else {
-                throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, errorLog);
+                throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, ERROR_LOG);
+            }
+        }
+    }
+    public List<XgDto> getXgListVal(String shootInfoList){
+        try{
+            ResponseEntity<XgDto[]> responseEntity = restTemplate.exchange("https://qgp7hgv778.execute-api.ap-northeast-2.amazonaws.com/Prod/xgrf", HttpMethod.POST, new HttpEntity<>(shootInfoList,headers),XgDto[].class);
+            return new ArrayList<>(Arrays.asList(responseEntity.getBody()));
+        }
+        catch(HttpClientErrorException | HttpServerErrorException e){
+            if (e.getRawStatusCode() == 429 || e.getRawStatusCode() == 403) {
+                throw new HttpClientErrorException(HttpStatus.FORBIDDEN , ERROR_LOG);
+            }  else {
+                throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, ERROR_LOG);
             }
         }
     }

--- a/serverlessapi/src/main/java/com/pds/serverlessapi/controller/XgController.java
+++ b/serverlessapi/src/main/java/com/pds/serverlessapi/controller/XgController.java
@@ -6,10 +6,14 @@ import com.pds.serverlessapi.api.XgDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +24,9 @@ public class XgController {
     @PostMapping("/expectedgoal")
     public ResponseEntity<XgDto> expectedGoalForShoot(@RequestBody String shootInfo){
             return ResponseEntity.ok(xgApi.getXgVal(shootInfo));
+    }
+    @PostMapping("/expectedgoals")
+    public ResponseEntity<List<XgDto>> expectedGoalListForShoots(@RequestBody String shootInfoList, HttpServletResponse response){
+        return ResponseEntity.ok(xgApi.getXgListVal(shootInfoList));
     }
 }

--- a/serverlessapi/src/test/java/com/pds/serverlessapi/api/ConSlApiTest.java
+++ b/serverlessapi/src/test/java/com/pds/serverlessapi/api/ConSlApiTest.java
@@ -1,6 +1,7 @@
 package com.pds.serverlessapi.api;
 
 import com.pds.serverlessapi.config.SlApiConfig;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +15,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+
+
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -32,6 +35,7 @@ class ConSlApiTest {
         assertNotNull(headers);
         assertNotNull(headers.get("x-api-key"));
     }
+
 
     @Test
     void conApiButNoBodyTest(){
@@ -58,4 +62,25 @@ class ConSlApiTest {
         JSONObject jsonObject = new JSONObject(responseEntity.getBody());
         assertTrue(jsonObject.has("prediction"));
     }
+
+    @Test
+    void conLogresListApiTest(){
+        String request = "{\n" +
+                "    \"inner\":\n" +
+                "    [\n" +
+                "    {\"assist\": 0, \"asx\": 0 , \"asy\": 0, \"fin\": \"1\", \"hed\": 0, \"inv\": 0, \"nom\": 0\n" +
+                ", \"x\": 0.88 ,\"y\": 0.45},\n" +
+                "{\"assist\": 0, \"asx\": 0 , \"asy\": 0, \"fin\": \"1\", \"hed\": 0, \"inv\": 0, \"nom\": 0\n" +
+                ", \"x\": 0.88 ,\"y\": 0.45 }\n" +
+                "    ]\n" +
+                "}";
+        HttpEntity<String> httpEntityHasBody = new HttpEntity<>(request, headers);
+        assertEquals(headers,httpEntityHasBody.getHeaders());
+        ResponseEntity<String> responseEntity = restTemplate.exchange("https://qgp7hgv778.execute-api.ap-northeast-2.amazonaws.com/Prod/xgrf", HttpMethod.POST, httpEntityHasBody, String.class);
+        assertEquals(200 , responseEntity.getStatusCodeValue());
+        JSONArray resultArray = new JSONArray(responseEntity.getBody());
+        assertEquals(2,resultArray.length());
+        assertTrue(resultArray.getJSONObject(0).has("prediction"));
+    }
+
 }

--- a/serverlessapi/src/test/java/com/pds/serverlessapi/api/XgApiTest.java
+++ b/serverlessapi/src/test/java/com/pds/serverlessapi/api/XgApiTest.java
@@ -6,16 +6,11 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
+import java.util.List;
 import  static org.junit.jupiter.api.Assertions.*;
+
 
 @SpringBootTest(classes = {XgApi.class , SlApiConfig.class, RestTemplate.class})
 class XgApiTest {
@@ -25,7 +20,7 @@ class XgApiTest {
 
     private final String exampleBody = "{\"assist\": 0, \"asx\": 0 , \"asy\": 0, \"fin\": 1, \"hed\": 0, \"inv\": 0, \"nom\": 0\n" +
             ", \"x\": 0.88 ,\"y\": 0.45}";
-
+    private final String exampleListBody = "{\"inner\": [{\"assist\": 0, \"asx\": 0 , \"asy\": 0, \"fin\": \"1\", \"hed\": 0, \"inv\": 0, \"nom\": 0, \"x\": 0.88 ,\"y\": 0.45},{\"assist\": 0, \"asx\": 0 , \"asy\": 0, \"fin\": \"1\", \"hed\": 0, \"inv\": 0, \"nom\": 0, \"x\": 0.88 ,\"y\": 0.45}]}";
     @Test
     void getXgTest() {
         XgDto xgDto = xgApi.getXgVal(exampleBody);
@@ -38,4 +33,17 @@ class XgApiTest {
         String invBody = exampleBody.replace(",\"y\": 0.45", "");
         assertThrows(HttpClientErrorException.class, () -> xgApi.getXgVal(invBody));
     }
+
+    @Test
+    void getXgListValTest(){
+        List<XgDto> xgDtoList = xgApi.getXgListVal(exampleListBody);
+        System.out.println(xgDtoList.get(0));
+    }
+
+    @Test
+    void getXgListWithInvalidDataTest() {
+        String invBody = exampleListBody.replace(",\"y\": 0.45", "");
+        assertThrows(HttpClientErrorException.class, () -> xgApi.getXgListVal(invBody));
+    }
+
 }

--- a/serverlessapi/src/test/java/com/pds/serverlessapi/controller/XgControllerTest.java
+++ b/serverlessapi/src/test/java/com/pds/serverlessapi/controller/XgControllerTest.java
@@ -1,26 +1,22 @@
 package com.pds.serverlessapi.controller;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pds.serverlessapi.api.XgApi;
 import com.pds.serverlessapi.api.XgDto;
-import com.sun.net.httpserver.HttpServer;
 import org.json.JSONObject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.util.NestedServletException;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static org.mockito.BDDMockito.given;
@@ -45,13 +41,25 @@ class XgControllerTest {
 
 
     @Test
-    void getDetailFromMatchCodeTest() throws Exception {
-        given(xgApi.getXgVal("SOMETHING"))
+    void expectedGoalForShootTest() throws Exception {
+        given(xgApi.getXgVal("Shootinfo"))
                 .willReturn(xgDto);
         MvcResult mvcResult = mvc.perform(post("/expectedgoal")
-                .content("SOMETHING")
+                .content("Shootinfo")
                 .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk()).andReturn();
         assertEquals(0.25,new JSONObject(mvcResult.getResponse().getContentAsString()).getDouble("prediction"));
+    }
+    @Test
+    void expectedGoalsForShootsTest() throws Exception{
+        List<XgDto> xgDtoList = new ArrayList<>();
+        xgDtoList.add(xgDto);
+        xgDtoList.add(xgDto);
+        given(xgApi.getXgListVal("Shootinfo"))
+                .willReturn(xgDtoList);
+        mvc.perform(post("/expectedgoals")
+                .content("Shootinfo")
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
**기존** 
개별 슛 데이터 -> 개별 기대득점 데이터

**변경** 
한 경기 한 유저의 슛 데이터 리스트 -> 해당되는 기대 득점 데이터 리스트

**이유** 
응답시간 개선 , api 응답횟수 감소 