### PR TITLE
tomcat 설정 config 클래스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ task jacocoRootReport(type: JacocoReport) {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect{
             fileTree(dir: it, excludes: [
-                    "com/pds/**/*Application.*"
+                    "com/pds/**/*Application.*","com/pds/web/config/*"
             ])
         }))
     }

--- a/web/src/main/java/com/pds/web/config/EmbeddedTomcatCustomizer.java
+++ b/web/src/main/java/com/pds/web/config/EmbeddedTomcatCustomizer.java
@@ -1,0 +1,23 @@
+package com.pds.web.config;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmbeddedTomcatCustomizer implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers((TomcatConnectorCustomizer) connector -> {
+            connector.setProperty("relaxedPathChars", "<>[\\]^`{|}");
+            connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}");
+        });
+    }
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory>
+    containerCustomizer(){
+        return new EmbeddedTomcatCustomizer();
+    }
+}


### PR DESCRIPTION
**문제**
java.lang.IllegalArgumentException: Invalid character found in the request target. The valid characters are defined in RFC 7230 and RFC 3986

-> get 방식 파라미터에 `[] 등 특수문자 넣을 시 발생하고 톰캣 400 페이지로 이동됨

**해결**
톰캣 서버 relaxedQueryChars 빈 설정으로 특수문자 허용